### PR TITLE
Make it easer to package vcsgui binaries on OS X

### DIFF
--- a/vcsgui/src/VCSGui/Common/SetupConfig.hs
+++ b/vcsgui/src/VCSGui/Common/SetupConfig.hs
@@ -21,8 +21,7 @@ import Data.Maybe
 import Control.Monad
 import System.Directory
 import System.Directory(doesDirectoryExist)
-import Data.List.Utils(elemRIndex)
-import Data.List(isInfixOf)
+import Data.List(findIndex)
 import Paths_vcsgui(getDataFileName)
 
 import VCSGui.Common.Error
@@ -241,15 +240,12 @@ initSetupRepoGui mbConfig gui = do
                                     H.set (entRepo gui) $ path
                                     availableVCS <- discoverVCS path
                                     H.set (comboBoxVCSType gui) $ map (\vcs -> show vcs) availableVCS
-                                    if isInfixOf [vcsType] availableVCS
-                                        then do
-                                        --get position (hopefully always index in liststore = index in list)
-                                        let index = elemRIndex vcsType availableVCS
-
-                                        --set active
-                                        comboBoxSetActive (H.getItem (comboBoxVCSType gui)) $ fromMaybe (-1) index
-                                        else do
-                                        return ()
+                                    --get position (hopefully always index in liststore = index in list)
+                                    case findIndex (== vcsType) availableVCS of
+                                        Just index ->
+                                            --set active
+                                            comboBoxSetActive (H.getItem (comboBoxVCSType gui)) index
+                                        _ -> return ()
                 case mbExec of
                     Nothing -> do
                                     H.set (checkbtExec gui) False

--- a/vcsgui/vcsgui.cabal
+++ b/vcsgui/vcsgui.cabal
@@ -34,7 +34,7 @@ flag gtk3
     default: True
 
 library
-    build-depends: MissingH >=1.1.0.3 && <1.3,
+    build-depends:
                filepath >=1.2.0.0 && < 1.4,
                base >=4.0.0.0 && <4.8,
                directory >=1.1.0.0 && <1.3,
@@ -63,7 +63,7 @@ library
 
 executable vcsgui
     main-is: Main.hs
-    build-depends: MissingH >=1.1.0.3 && <1.3,
+    build-depends:
                filepath >=1.2.0.0 && < 1.4,
                base >=4.0.0.0 && <4.8,
                directory >=1.1.0.0 && <1.3,
@@ -91,7 +91,7 @@ executable vcsgui
 
 executable vcsgui-askpass
     main-is: Main.hs
-    build-depends: MissingH >=1.1.0.3 && <1.3,
+    build-depends:
                filepath >=1.2.0.0 && < 1.4,
                base >=4.0.0.0 && <4.8,
                directory >=1.1.0.0 && <1.3,


### PR DESCRIPTION
Add linker setting that make it possible to update the paths to the GTK
libraries before including the vcsgui in a OS X app bundle.
